### PR TITLE
include LICENSE file in published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ categories = ["algorithms"]
 include = [
     "**/*.rs",
     "Cargo.toml",
-    "README.md"
+    "README.md",
+    "LICENSE",
 ]
 
 [[bench]]


### PR DESCRIPTION
Most Open-Source licenses ﻿require redistributed source code to contain a copy of the license file that covers that source code. Since the Boost 1.0 license is not an exception here, it needs to be included in crates that are published and redistributed via crates.io.

This will also make it possible for Linux distributions to package this crate, which is why I came across this issue. I am the maintainer of the Sequoia OpenPGP packages in Fedora Linux, and it started using this crate.