### PR TITLE
Correct getrandom dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ const_xxh3 = [] # Enable const xxh3 implementation
 
 [dev-dependencies]
 xxhash-c-sys = "0.8.3"
-getrandom = "0"
+getrandom = "0.2"
 
 [package.metadata.docs.rs]
 features = ["xxh32", "const_xxh32", "xxh64", "const_xxh64", "xxh3", "const_xxh3"]


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create. 