### PR TITLE
add `no-std::no-alloc` category and `no-std` keyword

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ description = "Implementation of xxhash"
 readme = "README.md"
 repository = "https://github.com/DoumanAsh/xxhash-rust"
 license = "BSL-1.0"
-keywords = ["hash", "xxhash", "xxh3", "hasher"]
-categories = ["algorithms"]
+keywords = ["hash", "xxhash", "xxh3", "hasher", "no-std"]
+categories = ["algorithms", "no-std::no-alloc"]
 include = [
     "**/*.rs",
     "Cargo.toml",


### PR DESCRIPTION
I wasn't sure whether this crate was no-std compatible or required allocations before looking at the source code.

This addition helps to immediatly recognize that fact and also improves discoverability.