### PR TITLE
Derive Clone for Xxh32/64

### DIFF
--- a/src/xxh32.rs
+++ b/src/xxh32.rs
@@ -91,6 +91,7 @@ pub fn xxh32(mut input: &[u8], seed: u32) -> u32 {
 }
 
 ///XXH32 Streaming algorithm
+#[derive(Clone)]
 pub struct Xxh32 {
     total_len: u32,
     is_large_len: bool,

--- a/src/xxh64.rs
+++ b/src/xxh64.rs
@@ -123,6 +123,7 @@ pub fn xxh64(mut input: &[u8], seed: u64) -> u64 {
 }
 
 ///XXH64 Streaming algorithm
+#[derive(Clone)]
 pub struct Xxh64 {
     total_len: u64,
     v1: u64,


### PR DESCRIPTION
In some obscure cases, like implementing Digest traits for non-cryptographical hashes, I could really use the `Clone` implementation to keep things simpler.

See https://github.com/nyurik/noncrypto-digests