### PR TITLE
Simplify the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ use xxhash_rust::xxh3::xxh3_64;
 const TEST: u64 = const_xxh3(b"TEST");
 
 fn test_input(text: &str) -> bool {
-    match xxh3_64(text.as_bytes()) {
-        TEST => true,
-        _ => false
-    }
+    xxh3_64(text.as_bytes()) == TEST
 }
 
 assert!(!test_input("tEST"));


### PR DESCRIPTION
There is no need to use a match for what is simply an integer comparison.