### PR TITLE
Inline finaliziers

### DIFF
--- a/src/xxh3.rs
+++ b/src/xxh3.rs
@@ -1046,6 +1046,7 @@ impl Xxh3Default {
         ((high as u128) << 64) | (low as u128)
     }
 
+    #[inline]
     ///Computes hash.
     pub fn digest(&self) -> u64 {
         //Separating digest mid sized allows us to inline this function, which benefits
@@ -1057,6 +1058,7 @@ impl Xxh3Default {
         }
     }
 
+    #[inline]
     ///Computes hash as 128bit integer.
     pub fn digest128(&self) -> u128 {
         //Separating digest mid sized allows us to inline this function, which benefits
@@ -1205,6 +1207,7 @@ impl Xxh3 {
         ((high as u128) << 64) | (low as u128)
     }
 
+    #[inline]
     ///Computes hash.
     pub fn digest(&self) -> u64 {
         //Separating digest mid sized allows us to inline this function, which benefits
@@ -1220,6 +1223,7 @@ impl Xxh3 {
         }
     }
 
+    #[inline]
     ///Computes hash as 128bit integer.
     pub fn digest128(&self) -> u128 {
         //Separating digest mid sized allows us to inline this function, which benefits


### PR DESCRIPTION
This encourages LLVM to inline `.digest()` into the caller. Currently, while the comments explicitly refer to inlining, LLVM does not inline these methods for all cases I measured, but does with the attribute. Notice that `#[inline]` remains the weaker suggestion compared to `#[inline(always)]`, but it brings us over the line (_pun intended_).

Currently, LLVM does not actually take information from surrounding code into account.  The benefit of adding `#[inline]` therefor is mainly around the `Hasher`-implementation or when not using the explicit one-shot path: LLVM will inline the entire thing into the caller when it then can aggressively remove all the state-handling, usually if the to-be-hashed value has a compile-time-known size. Hashing a `T` via `T: std::hash::Hash` where `T` is `u64` goes down by around -67% runtime, `[u64; 4]` down by -76%; similar small objects mostly the same; longer slices are mostly flat. Think of `HashMap<u64, ...>` as a beneficiary.

Inlining-changes are always somewhat opaque, so I encourage to benchmark yourself. I tested this change on AArch64 with Rust 1.81, 1.97, ThinLTO enabled/disabled, various codegen-unit settings, and - at least as far as the assembly goes - x86-64. The added hints consistently come with performance benefits especially around small-ish, constant-size objects; LLVM also does not over-aggressively inline e.g. for dynamic buffers. YMMV, but as far as I can see this is a win.