### PR TITLE
Ensure Xxh3Builder seed/secret are order-independent

### DIFF
--- a/src/xxh3.rs
+++ b/src/xxh3.rs
@@ -1307,20 +1307,12 @@ impl Xxh3Builder {
     #[inline(always)]
     ///Creates `Xxh3` instance
     pub const fn build(self) -> Xxh3 {
-        let (seed, secret) = match self.seed {
-            Some(seed) => match self.secret {
-                //Use user's secret
-                Some(secret) => (seed, secret),
-                //Derive secret from seed
-                None => (seed, const_custom_default_secret(seed)),
-            },
-            None => match self.secret {
-                //Use user's secret
-                Some(secret) => (0, secret),
-                //Default hasher config
-                None => (0, DEFAULT_SECRET)
-            }
-        };
+        let (seed, secret) = match (self.seed, self.secret) {
+            (Some(seed), Some(secret)) => (seed, secret),
+            (Some(seed), None) => (seed, const_custom_default_secret(seed)),
+            (None, Some(secret)) => (0, secret),
+            (None, None) => (0, DEFAULT_SECRET),
+            };
         Xxh3::with_custom_ops(seed, secret)
     }
 }

--- a/tests/assert_correctness.rs
+++ b/tests/assert_correctness.rs
@@ -261,3 +261,27 @@ fn assert_xxh3() {
         hasher_default_128.reset();
     }
 }
+
+#[cfg(feature = "xxh3")]
+#[test]
+fn xxh3_builder_seed_and_secret_are_order_independent() {
+    use xxhash_rust::xxh3::Xxh3Builder;
+
+    const SEED: u64 = 0x0123_4567_89ab_cdef;
+    const SECRET: [u8; 192] = [0xa5; 192];
+    const INPUT: [u8; 241] = [0x42; 241];
+
+    let mut seed_then_secret = Xxh3Builder::new()
+        .with_seed(SEED)
+        .with_secret(SECRET)
+        .build();
+    let mut secret_then_seed = Xxh3Builder::new()
+        .with_secret(SECRET)
+        .with_seed(SEED)
+        .build();
+
+    seed_then_secret.update(&INPUT);
+    secret_then_seed.update(&INPUT);
+
+    assert_eq!(seed_then_secret.digest(), secret_then_seed.digest());
+}


### PR DESCRIPTION
Mainly this adds a test for #54 (which now passes after 0ec2a5b8e3b6ed30c481ca08c9eaccd035f878de), and also very slightly refactors the nested `match`